### PR TITLE
Removed capslock and numlock modifier from the keybindings

### DIFF
--- a/assets/default_config.toml
+++ b/assets/default_config.toml
@@ -21,7 +21,7 @@ text_query = '#e5c07bff'    # for the search query
 text_selected = '#61afefff' # for the currently selected result
 
 [keybindings]
-# keybindings syntax: ctrl/shift/alt/num_lock/caps_lock/logo as modifiers and a key joined by '+' signs
+# keybindings syntax: ctrl/shift/alt/caps_lock/logo as modifiers and a key joined by '+' signs
 # A list of available keys can be found here: https://docs.rs/crate/x11-keysymdef/0.2.0/source/src/keysym.json
 paste = ["ctrl+v"]
 execute = ["KP_Enter", "Return"]

--- a/assets/default_config.toml
+++ b/assets/default_config.toml
@@ -21,7 +21,7 @@ text_query = '#e5c07bff'    # for the search query
 text_selected = '#61afefff' # for the currently selected result
 
 [keybindings]
-# keybindings syntax: ctrl/shift/alt/caps_lock/logo as modifiers and a key joined by '+' signs
+# keybindings syntax: ctrl/shift/alt/logo as modifiers and a key joined by '+' signs
 # A list of available keys can be found here: https://docs.rs/crate/x11-keysymdef/0.2.0/source/src/keysym.json
 paste = ["ctrl+v"]
 execute = ["KP_Enter", "Return"]

--- a/src/keybinds.rs
+++ b/src/keybinds.rs
@@ -47,7 +47,6 @@ impl Hash for Modifiers {
         self.0.ctrl.hash(state);
         self.0.caps_lock.hash(state);
         self.0.logo.hash(state);
-        self.0.num_lock.hash(state);
     }
 }
 
@@ -58,7 +57,6 @@ impl PartialEq for Modifiers {
             && self.0.shift == other.0.shift
             && self.0.caps_lock == other.0.caps_lock
             && self.0.logo == other.0.logo
-            && self.0.num_lock == other.0.num_lock
     }
 }
 impl Eq for Modifiers {}
@@ -115,7 +113,6 @@ impl<'de> Visitor<'de> for KeyComboVisitor {
         value.split("+").for_each(|s| match s {
             "ctrl" => modifiers.ctrl = true,
             "shift" => modifiers.shift = true,
-            "num_lock" => modifiers.num_lock = true,
             "caps_lock" => modifiers.caps_lock = true,
             "alt" => modifiers.alt = true,
             "logo" => modifiers.logo = true,

--- a/src/keybinds.rs
+++ b/src/keybinds.rs
@@ -45,7 +45,6 @@ impl Hash for Modifiers {
         self.0.alt.hash(state);
         self.0.shift.hash(state);
         self.0.ctrl.hash(state);
-        self.0.caps_lock.hash(state);
         self.0.logo.hash(state);
     }
 }
@@ -55,7 +54,6 @@ impl PartialEq for Modifiers {
         self.0.ctrl == other.0.ctrl
             && self.0.alt == other.0.alt
             && self.0.shift == other.0.shift
-            && self.0.caps_lock == other.0.caps_lock
             && self.0.logo == other.0.logo
     }
 }
@@ -113,7 +111,6 @@ impl<'de> Visitor<'de> for KeyComboVisitor {
         value.split("+").for_each(|s| match s {
             "ctrl" => modifiers.ctrl = true,
             "shift" => modifiers.shift = true,
-            "caps_lock" => modifiers.caps_lock = true,
             "alt" => modifiers.alt = true,
             "logo" => modifiers.logo = true,
             s => {


### PR DESCRIPTION
Hello, while developing a new feature for this awesome launcher i noticed problems with the new keybinding feature. After digging in the debugger i noticed that i had num_lock activated while kickoff expects it to be deactivated. Furthermore i would like to argue if its sensible to include the num_lock into keybindings since its a lock key and/or state than a pressed key.

The same could be argued for caps_lock, please comment than i remove that too.

Thanks in advance.