### PR TITLE
Use --prompt argument

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -169,7 +169,7 @@ impl App {
         let mut img =
             ImageBuffer::from_pixel(width, height, self.config.colors.background.to_rgba());
         let prompt = match &self.args.prompt {
-            Some(s) => s,
+            Some(prompt) => prompt,
             None => &self.config.prompt,
         };
         let prompt_width = if !prompt.is_empty() {

--- a/src/app.rs
+++ b/src/app.rs
@@ -168,7 +168,10 @@ impl App {
 
         let mut img =
             ImageBuffer::from_pixel(width, height, self.config.colors.background.to_rgba());
-        let prompt = &self.config.prompt;
+        let prompt = match &self.args.prompt {
+            Some(s) => s,
+            None => &self.config.prompt,
+        };
         let prompt_width = if !prompt.is_empty() {
             let (width, _) = self.font.render(
                 prompt,


### PR DESCRIPTION
It looked like the prompt argument was made a no-op at some point and only the prompt value in the config file was considered. This PR re-adds support for passing a `-p/--prompt` option when used via the command line.

Let me know if there's anything that needs to be changed.