### PR TITLE
fix(gui): ignore exclusive zones

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -72,6 +72,7 @@ pub fn run(app: App) {
 
     layer.set_anchor(Anchor::all());
     layer.set_keyboard_interactivity(KeyboardInteractivity::Exclusive);
+    layer.set_exclusive_zone(-1);
 
     layer.commit();
 


### PR DESCRIPTION
Status bars often set an exclusive zone, so other programs don't overwrite its area.
This is undesirable for a program launcher if it is used in full-screen.
This PR sets the exclusive zone to -1 to hint the compositor to ignore exclusive zones set by other programs when moving and sizing the window.

Closes #219 